### PR TITLE
Stick with serverless 1.38.x for now...

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "serverless": "^1.38.0",
+    "serverless": "1.38.0",
     "serverless-rust": "^0.3.1"
   }
 }


### PR DESCRIPTION
... since there's a bug I've just hit with 1.39.x when defining multiple lambda functions:

https://github.com/serverless/serverless/issues/4720